### PR TITLE
feat(calibration): deploy Platt-calibrated binary P(toxic) + richer calibration metrics

### DIFF
--- a/scripts/package_models.py
+++ b/scripts/package_models.py
@@ -54,6 +54,10 @@ KEEP_FILES = (
     # Records the split manifest the checkpoint was calibrated against. `eval` and
     # `predict test_set/val_set` refuse a checkpoint without it.
     "models/split_provenance.json",
+    # Deployed Platt calibrator + Youden threshold for the binary P(toxic) score.
+    # predict/eval apply it (model.inference._load_binary_calibrator); without it
+    # they fall back to the raw score + 0.5. Regenerate via `toxfam eval binary`.
+    "models/binary_calibrator.json",
 )
 
 

--- a/src/toxfam/evaluation/binary.py
+++ b/src/toxfam/evaluation/binary.py
@@ -111,23 +111,45 @@ def run_binary_evaluation(
     Returns the binary results dict.
     """
     from toxfam.evaluation.metrics import (
+        PlattCalibrator,
+        binary_calibration_analysis,
         calculate_binary_metrics_with_scores,
         find_optimal_threshold,
     )
 
     console.print("\n[bold]Running Binary Metrics Pipeline...[/bold]")
 
-    # Val set — threshold optimization
+    # Raw P(toxic) — inherits the 38-class temperature (systematically over-toxic).
     val_y_true = compute_binary_labels(val_df, label_col)
-    val_p_toxic = compute_p_toxic(model, val_df, config, label_encoder, label_col)
+    val_p_raw = compute_p_toxic(model, val_df, config, label_encoder, label_col)
+    test_y_true = compute_binary_labels(test_df, label_col)
+    test_p_raw = compute_p_toxic(model, test_df, config, label_encoder, label_col)
 
+    # Recommendation #1 (DEPLOYED): fit a dedicated Platt calibrator for P(toxic)
+    # on val and score on the calibrated probability. The raw-vs-calibrated
+    # diagnostic (ECE/Brier/NLL + bootstrap CIs) is kept in binary_calibration.json;
+    # the calibrator itself is persisted to models/binary_calibrator.json so predict
+    # and eval apply it. Platt is monotonic, so ROC-AUC/PR-AUC are unchanged.
+    binary_cal = binary_calibration_analysis(
+        val_p_raw, val_y_true, test_p_raw, test_y_true, n_boot=1000, seed=42
+    )
+    calibrator = PlattCalibrator.from_dict(binary_cal["platt"])
+    val_p_toxic = calibrator.transform(val_p_raw)
+    test_p_toxic = calibrator.transform(test_p_raw)
+    console.print(
+        f"  Binary P(toxic) Platt-calibrated — ECE {binary_cal['test_raw']['ece']:.4f} "
+        f"→ {binary_cal['test_calibrated']['ece']:.4f}, "
+        f"Brier {binary_cal['test_raw']['brier']:.4f} "
+        f"→ {binary_cal['test_calibrated']['brier']:.4f} "
+        f"(ROC-AUC unchanged {binary_cal['roc_auc_raw']:.4f})"
+    )
+
+    # Threshold optimized in CALIBRATED score space, to match the deployed P(toxic).
     thresh_result = find_optimal_threshold(val_y_true, val_p_toxic, method="youden")
     opt_threshold = thresh_result["optimal_threshold"]
-    console.print(f"  Optimized threshold (Youden's J): {opt_threshold:.4f}")
-
-    # Test set — evaluate at both thresholds
-    test_y_true = compute_binary_labels(test_df, label_col)
-    test_p_toxic = compute_p_toxic(model, test_df, config, label_encoder, label_col)
+    console.print(
+        f"  Deployed threshold (Youden's J, calibrated space): {opt_threshold:.4f}"
+    )
 
     test_default = calculate_binary_metrics_with_scores(
         test_y_true, test_p_toxic, threshold=0.5
@@ -145,7 +167,19 @@ def run_binary_evaluation(
         f"PR-AUC={test_opt['pr_auc']:.4f}, MCC={test_opt['mcc']:.4f}"
     )
 
-    # Save metrics
+    # Persist the deployed calibrator next to the checkpoint so it ships with the
+    # model and predict/eval load it (see model.inference._load_binary_calibrator).
+    models_dir = output_dir / "models"
+    models_dir.mkdir(exist_ok=True)
+    (models_dir / "binary_calibrator.json").write_text(
+        json.dumps(
+            {**calibrator.to_dict(), "threshold": opt_threshold,
+             "threshold_space": "platt"},
+            indent=4,
+        )
+    )
+
+    # Save metrics — binary_metrics.json now reports the DEPLOYED (calibrated) score.
     metrics_dir = output_dir / "metrics"
     metrics_dir.mkdir(exist_ok=True)
     _curve_keys = {
@@ -154,11 +188,15 @@ def run_binary_evaluation(
     }
     binary_results = {
         "optimized_threshold": opt_threshold,
+        "score_space": "platt_calibrated",
         "test_default": {k: v for k, v in test_default.items() if k not in _curve_keys},
         "test_optimized": {k: v for k, v in test_opt.items() if k not in _curve_keys},
     }
     (metrics_dir / "binary_metrics.json").write_text(
         json.dumps(binary_results, indent=4)
+    )
+    (metrics_dir / "binary_calibration.json").write_text(
+        json.dumps(binary_cal, indent=4)
     )
 
     # Plots

--- a/src/toxfam/evaluation/binary.py
+++ b/src/toxfam/evaluation/binary.py
@@ -168,7 +168,7 @@ def run_binary_evaluation(
     )
 
     # Persist the deployed calibrator next to the checkpoint so it ships with the
-    # model and predict/eval load it (see model.inference._load_binary_calibrator).
+    # model and predict/eval load it (see model.inference._load_binary_calibration).
     models_dir = output_dir / "models"
     models_dir.mkdir(exist_ok=True)
     (models_dir / "binary_calibrator.json").write_text(

--- a/src/toxfam/evaluation/metrics.py
+++ b/src/toxfam/evaluation/metrics.py
@@ -312,12 +312,18 @@ def _reliability_ece(
     return float(ece)
 
 
-def top_label_ece(probs: np.ndarray, labels: np.ndarray, n_bins: int = 15) -> float:
-    """Top-1 confidence ECE (Guo et al.'s notion): calibration of max prob."""
+def _top_conf_acc(
+    probs: np.ndarray, labels: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Per-sample top-1 confidence (max prob) and 0/1 correctness of the argmax."""
     probs = np.asarray(probs, dtype=float)
     labels = np.asarray(labels)
-    confidences = probs.max(axis=1)
-    accuracies = (probs.argmax(axis=1) == labels).astype(float)
+    return probs.max(axis=1), (probs.argmax(axis=1) == labels).astype(float)
+
+
+def top_label_ece(probs: np.ndarray, labels: np.ndarray, n_bins: int = 15) -> float:
+    """Top-1 confidence ECE (Guo et al.'s notion): calibration of max prob."""
+    confidences, accuracies = _top_conf_acc(probs, labels)
     return _reliability_ece(confidences, accuracies, n_bins)
 
 
@@ -327,10 +333,7 @@ def adaptive_ece(probs: np.ndarray, labels: np.ndarray, n_bins: int = 15) -> flo
     Removes ECE's sensitivity to empty/underpopulated high-confidence bins by
     putting an equal number of samples in each bin (Nixon et al. 2019).
     """
-    probs = np.asarray(probs, dtype=float)
-    labels = np.asarray(labels)
-    confidences = probs.max(axis=1)
-    accuracies = (probs.argmax(axis=1) == labels).astype(float)
+    confidences, accuracies = _top_conf_acc(probs, labels)
     n = len(confidences)
     if n == 0:
         return 0.0
@@ -423,11 +426,20 @@ def multiclass_calibration_report(
     probs: np.ndarray, labels: np.ndarray, n_bins: int = 15
 ) -> dict[str, float]:
     """All calibration metrics for a multiclass prob matrix + integer labels."""
+    # Reduce the per-class reliability pass two ways (unweighted + support-weighted)
+    # from a single computation, rather than looping every class × bin twice.
+    per_class = classwise_ece_per_class(probs, labels, n_bins)
+    eces = [e["ece"] for e in per_class]
+    n = len(np.asarray(labels))
     return {
         "ece": top_label_ece(probs, labels, n_bins),
         "adaptive_ece": adaptive_ece(probs, labels, n_bins),
-        "classwise_ece": classwise_ece(probs, labels, n_bins),
-        "classwise_ece_weighted": classwise_ece_weighted(probs, labels, n_bins),
+        "classwise_ece": float(np.mean(eces)) if eces else 0.0,
+        "classwise_ece_weighted": (
+            float(sum(e["ece"] * e["support"] for e in per_class) / n)
+            if n and per_class
+            else 0.0
+        ),
         "brier": brier_score(probs, labels),
         "nll": nll_score(probs, labels),
     }

--- a/src/toxfam/evaluation/metrics.py
+++ b/src/toxfam/evaluation/metrics.py
@@ -267,6 +267,304 @@ def calculate_binary_metrics_with_scores(
     }
 
 
+# ---------------------------------------------------------------------------
+# Calibration-quality metrics
+#
+# Global temperature scaling (ModelWithTemperature) is judged in-repo only by
+# top-1 ECE. These add the richer notions the calibration literature uses to
+# decide whether a single scalar is enough: classwise-ECE / Static Calibration
+# Error (per-class one-vs-rest reliability), adaptive (equal-mass) ECE, Brier,
+# and NLL. See Kull et al. NeurIPS 2019 (classwise-ECE) and Nixon et al.
+# CVPRW 2019 (binning sensitivity / SCE).
+# ---------------------------------------------------------------------------
+
+
+def _onehot(labels: np.ndarray, n_classes: int) -> np.ndarray:
+    oh = np.zeros((len(labels), n_classes), dtype=float)
+    oh[np.arange(len(labels)), labels] = 1.0
+    return oh
+
+
+def _reliability_ece(
+    scores: np.ndarray, positives: np.ndarray, n_bins: int
+) -> float:
+    """Binned reliability gap E|conf - freq| for one score vs its outcome.
+
+    ``scores`` is a per-sample probability, ``positives`` the matching 0/1
+    outcome. Equal-width bins on [0, 1], lower-exclusive / upper-inclusive to
+    match the torch ``_ECELoss`` used during calibration; the first bin also
+    captures an exact-zero score so a never-predicted class still contributes.
+    """
+    scores = np.asarray(scores, dtype=float)
+    positives = np.asarray(positives, dtype=float)
+    n = len(scores)
+    if n == 0:
+        return 0.0
+    boundaries = np.linspace(0.0, 1.0, n_bins + 1)
+    ece = 0.0
+    for lo, hi in zip(boundaries[:-1], boundaries[1:]):
+        in_bin = (scores > lo) & (scores <= hi)
+        if lo == 0.0:
+            in_bin = in_bin | (scores == 0.0)
+        prop = in_bin.mean()
+        if prop > 0:
+            ece += abs(positives[in_bin].mean() - scores[in_bin].mean()) * prop
+    return float(ece)
+
+
+def top_label_ece(probs: np.ndarray, labels: np.ndarray, n_bins: int = 15) -> float:
+    """Top-1 confidence ECE (Guo et al.'s notion): calibration of max prob."""
+    probs = np.asarray(probs, dtype=float)
+    labels = np.asarray(labels)
+    confidences = probs.max(axis=1)
+    accuracies = (probs.argmax(axis=1) == labels).astype(float)
+    return _reliability_ece(confidences, accuracies, n_bins)
+
+
+def adaptive_ece(probs: np.ndarray, labels: np.ndarray, n_bins: int = 15) -> float:
+    """Adaptive ECE (ACE): equal-mass confidence bins instead of equal-width.
+
+    Removes ECE's sensitivity to empty/underpopulated high-confidence bins by
+    putting an equal number of samples in each bin (Nixon et al. 2019).
+    """
+    probs = np.asarray(probs, dtype=float)
+    labels = np.asarray(labels)
+    confidences = probs.max(axis=1)
+    accuracies = (probs.argmax(axis=1) == labels).astype(float)
+    n = len(confidences)
+    if n == 0:
+        return 0.0
+    order = np.argsort(confidences, kind="stable")
+    conf_sorted = confidences[order]
+    acc_sorted = accuracies[order]
+    ece = 0.0
+    for idx in np.array_split(np.arange(n), min(n_bins, n)):
+        if len(idx) == 0:
+            continue
+        ece += abs(acc_sorted[idx].mean() - conf_sorted[idx].mean()) * (len(idx) / n)
+    return float(ece)
+
+
+def classwise_ece_per_class(
+    probs: np.ndarray, labels: np.ndarray, n_bins: int = 15
+) -> list[dict[str, Any]]:
+    """Per-class one-vs-rest ECE with its test support, one entry per class.
+
+    The honest way to read classwise reliability on an imbalanced many-class
+    problem: the aggregate is dominated by near-empty classes (each ~0), so the
+    per-class breakdown (with support) is needed to see whether a *populated*
+    class is miscalibrated.
+    """
+    probs = np.asarray(probs, dtype=float)
+    labels = np.asarray(labels)
+    n_classes = probs.shape[1]
+    out = []
+    for c in range(n_classes):
+        yc = (labels == c).astype(float)
+        out.append(
+            {
+                "class_index": c,
+                "support": int(yc.sum()),
+                "ece": _reliability_ece(probs[:, c], yc, n_bins),
+            }
+        )
+    return out
+
+
+def classwise_ece(probs: np.ndarray, labels: np.ndarray, n_bins: int = 15) -> float:
+    """Classwise-ECE / Static Calibration Error: mean per-class one-vs-rest ECE.
+
+    For each class ``c`` it bins ``probs[:, c]`` and compares the mean predicted
+    probability to the empirical frequency of that class in the bin, then
+    averages over classes. Unlike top-1 ECE this exposes per-class over/under-
+    confidence a single global temperature cannot fix (Kull et al. 2019).
+
+    NOTE: this is the *unweighted* mean over classes. On an imbalanced
+    many-class problem it is diluted toward 0 by near-empty classes — read it
+    alongside :func:`classwise_ece_weighted` and :func:`classwise_ece_per_class`.
+    """
+    per_class = classwise_ece_per_class(probs, labels, n_bins)
+    return float(np.mean([e["ece"] for e in per_class])) if per_class else 0.0
+
+
+def classwise_ece_weighted(
+    probs: np.ndarray, labels: np.ndarray, n_bins: int = 15
+) -> float:
+    """Support-weighted classwise-ECE: per-class ECE weighted by class frequency.
+
+    De-dilutes the plain mean: a miscalibrated populated class dominates instead
+    of being averaged away against many empty classes. This is the classwise
+    number that actually bears on "would a per-class recalibrator help here?".
+    """
+    per_class = classwise_ece_per_class(probs, labels, n_bins)
+    n = len(np.asarray(labels))
+    if n == 0 or not per_class:
+        return 0.0
+    return float(sum(e["ece"] * e["support"] for e in per_class) / n)
+
+
+def brier_score(probs: np.ndarray, labels: np.ndarray) -> float:
+    """Multiclass Brier score: mean sum_c (p_c - onehot_c)^2, range [0, 2]."""
+    probs = np.asarray(probs, dtype=float)
+    labels = np.asarray(labels)
+    oh = _onehot(labels, probs.shape[1])
+    return float(np.mean(np.sum((probs - oh) ** 2, axis=1)))
+
+
+def nll_score(probs: np.ndarray, labels: np.ndarray, eps: float = 1e-12) -> float:
+    """Negative log-likelihood (multiclass cross-entropy), matches log_loss."""
+    probs = np.asarray(probs, dtype=float)
+    labels = np.asarray(labels)
+    p_true = np.clip(probs[np.arange(len(labels)), labels], eps, 1.0)
+    return float(-np.mean(np.log(p_true)))
+
+
+def multiclass_calibration_report(
+    probs: np.ndarray, labels: np.ndarray, n_bins: int = 15
+) -> dict[str, float]:
+    """All calibration metrics for a multiclass prob matrix + integer labels."""
+    return {
+        "ece": top_label_ece(probs, labels, n_bins),
+        "adaptive_ece": adaptive_ece(probs, labels, n_bins),
+        "classwise_ece": classwise_ece(probs, labels, n_bins),
+        "classwise_ece_weighted": classwise_ece_weighted(probs, labels, n_bins),
+        "brier": brier_score(probs, labels),
+        "nll": nll_score(probs, labels),
+    }
+
+
+def binary_calibration_report(
+    p_toxic: np.ndarray, y_true: np.ndarray, n_bins: int = 15
+) -> dict[str, float]:
+    """Calibration metrics for a scalar P(toxic) score against 0/1 labels.
+
+    ``ece`` here is positive-class reliability (bin P(toxic), compare to the
+    empirical toxic frequency) — the exact quantity a separate binary
+    calibrator (:class:`PlattCalibrator`) targets. ``brier`` is the standard
+    single-event binary Brier ``mean((p - y)^2)`` (== sklearn brier_score_loss),
+    not the two-column multiclass sum.
+    """
+    p = np.asarray(p_toxic, dtype=float)
+    y = np.asarray(y_true, dtype=float)
+    return {
+        "ece": _reliability_ece(p, (y == 1).astype(float), n_bins),
+        "brier": float(np.mean((p - y) ** 2)),
+        "nll": nll_score(np.column_stack([1.0 - p, p]), y.astype(int)),
+    }
+
+
+class PlattCalibrator:
+    """Platt scaling for a single binary score: sigmoid(a * logit(s) + b).
+
+    Recalibrates the derived P(toxic) = 1 - sum(P(nontoxin)) score with its own
+    two parameters instead of inheriting the 38-class temperature. The map is
+    monotonic (a > 0 in practice), so it is rank-preserving: it changes ECE /
+    Brier / NLL and the fixed-0.5 operating point, but not ROC-AUC / PR-AUC.
+    """
+
+    def __init__(self, a: float = 1.0, b: float = 0.0, eps: float = 1e-6) -> None:
+        self.a = a
+        self.b = b
+        self.eps = eps
+
+    def _logit(self, s: np.ndarray) -> np.ndarray:
+        s = np.clip(np.asarray(s, dtype=float), self.eps, 1.0 - self.eps)
+        return np.log(s / (1.0 - s))
+
+    def fit(self, scores: np.ndarray, y: np.ndarray) -> PlattCalibrator:
+        from sklearn.linear_model import LogisticRegression
+
+        x = self._logit(scores).reshape(-1, 1)
+        y = np.asarray(y).astype(int)
+        # A single observed class (or <2 samples) has no calibration signal and
+        # would crash LogisticRegression — fall back to the identity map.
+        if len(y) < 2 or np.unique(y).size < 2:
+            self.a, self.b = 1.0, 0.0
+            return self
+        # Unregularized MLE — the canonical Platt fit for a single feature.
+        lr = LogisticRegression(penalty=None, solver="lbfgs", max_iter=1000)
+        # Well-separated scores make the L-BFGS line search touch large weights,
+        # which trips spurious BLAS "divide by zero / overflow in matmul" FP
+        # flags; the fit still converges. Silence just those FP flags.
+        with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
+            lr.fit(x, y)
+        self.a = float(lr.coef_[0, 0])
+        self.b = float(lr.intercept_[0])
+        return self
+
+    def transform(self, scores: np.ndarray) -> np.ndarray:
+        z = self.a * self._logit(scores) + self.b
+        return np.clip(1.0 / (1.0 + np.exp(-z)), 0.0, 1.0)
+
+    def to_dict(self) -> dict[str, float]:
+        return {"a": self.a, "b": self.b, "eps": self.eps}
+
+    @classmethod
+    def from_dict(cls, d: dict[str, float]) -> PlattCalibrator:
+        return cls(a=d["a"], b=d["b"], eps=d.get("eps", 1e-6))
+
+
+def binary_calibration_analysis(
+    val_p_toxic: np.ndarray,
+    val_y: np.ndarray,
+    test_p_toxic: np.ndarray,
+    test_y: np.ndarray,
+    *,
+    n_bins: int = 15,
+    n_boot: int = 0,
+    seed: int = 0,
+) -> dict[str, Any]:
+    """Fit a Platt calibrator for P(toxic) on val, measure its effect on test.
+
+    Answers "does the derived binary score deserve its own calibrator?" — it
+    fits Platt on the validation P(toxic)/label pairs and reports the change in
+    calibration (ECE/Brier/NLL) on the held-out test set, plus a rank-preserving
+    sanity check that ROC-AUC is unchanged. Pure: numpy in, JSON-able dict out.
+
+    With ``n_boot > 0`` it adds ``delta_ci95``: percentile bootstrap 95% CIs for
+    each metric's change, resampling the test set with the (val-fixed) calibrator
+    held constant. Binned ECE is a positively-biased small-sample estimator, so
+    the point delta alone overstates certainty — the CI is what makes the effect
+    size interpretable.
+    """
+    cal = PlattCalibrator().fit(val_p_toxic, val_y)
+    test_p_toxic = np.asarray(test_p_toxic, dtype=float)
+    test_y = np.asarray(test_y)
+    test_cal = cal.transform(test_p_toxic)
+
+    raw = binary_calibration_report(test_p_toxic, test_y, n_bins)
+    calibrated = binary_calibration_report(test_cal, test_y, n_bins)
+    delta = {k: calibrated[k] - raw[k] for k in raw}
+
+    result = {
+        "platt": cal.to_dict(),
+        "n_bins": n_bins,
+        "test_raw": raw,
+        "test_calibrated": calibrated,
+        "delta": delta,
+        "roc_auc_raw": float(roc_auc_score(test_y, test_p_toxic)),
+        "roc_auc_calibrated": float(roc_auc_score(test_y, test_cal)),
+    }
+
+    if n_boot > 0:
+        rng = np.random.default_rng(seed)
+        n = len(test_y)
+        boot = {k: [] for k in delta}
+        for _ in range(n_boot):
+            idx = rng.integers(0, n, n)
+            r = binary_calibration_report(test_p_toxic[idx], test_y[idx], n_bins)
+            c = binary_calibration_report(test_cal[idx], test_y[idx], n_bins)
+            for k in delta:
+                boot[k].append(c[k] - r[k])
+        result["delta_ci95"] = {
+            k: [float(np.percentile(v, 2.5)), float(np.percentile(v, 97.5))]
+            for k, v in boot.items()
+        }
+        result["n_boot"] = n_boot
+
+    return result
+
+
 def find_optimal_threshold(
     y_true: np.ndarray,
     y_scores: np.ndarray,

--- a/src/toxfam/model/inference.py
+++ b/src/toxfam/model/inference.py
@@ -123,7 +123,9 @@ def _load_binary_calibration(model_dir: str | Path) -> _BinaryCalibration | None
     try:
         d = json.loads(path.read_text())
         return _BinaryCalibration(PlattCalibrator.from_dict(d), float(d["threshold"]))
-    except (json.JSONDecodeError, KeyError, ValueError, OSError):
+    except (json.JSONDecodeError, KeyError, ValueError, TypeError, OSError):
+        # TypeError covers a null / non-numeric "threshold" (float(None)); a
+        # calibrator we cannot fully parse must degrade to the raw path, not crash.
         return None
 
 

--- a/src/toxfam/model/inference.py
+++ b/src/toxfam/model/inference.py
@@ -93,6 +93,25 @@ def load_calibrated_model(
     return scaled_model, model_config, idx_to_label
 
 
+def _load_binary_calibrator(model_dir: str | Path):
+    """Load the deployed binary P(toxic) calibrator, or None if absent.
+
+    ``models/binary_calibrator.json`` is written by ``run_binary_evaluation``
+    when a checkpoint is calibrated. Its absence (older checkpoints) means the
+    raw P(toxic) is used, so this returns None and the caller leaves the score
+    unchanged. See ``toxfam.evaluation.metrics.PlattCalibrator``.
+    """
+    from toxfam.evaluation.metrics import PlattCalibrator
+
+    path = Path(model_dir) / "models" / "binary_calibrator.json"
+    if not path.exists():
+        return None
+    try:
+        return PlattCalibrator.from_dict(json.loads(path.read_text()))
+    except (json.JSONDecodeError, KeyError, ValueError, OSError):
+        return None
+
+
 def _resolve_tax_h5(model_dir: Path) -> Path | None:
     """Read tax_h5_path from the saved config.yaml in the model directory."""
     config_yaml = model_dir / "config.yaml"
@@ -295,6 +314,16 @@ def run_topk_inference(
         p_toxic = 1.0 - cal_probs[:, nontox_indices].sum(dim=1)
     else:
         p_toxic = torch.ones(len(identifiers))
+
+    # Deployed binary calibration (recommendation #1): recalibrate the derived
+    # P(toxic) with the checkpoint's Platt calibrator when present. Monotonic, so
+    # it changes no ranking — only the probability value (and the 0.5 point).
+    # The family predictions/confidence above are NOT touched.
+    binary_calibrator = _load_binary_calibrator(model_dir)
+    if binary_calibrator is not None:
+        p_toxic = torch.as_tensor(
+            binary_calibrator.transform(p_toxic.numpy()), dtype=torch.float32
+        )
 
     if binary_only:
         return pd.DataFrame({"identifier": identifiers, "p_toxic": p_toxic.tolist()})

--- a/src/toxfam/model/inference.py
+++ b/src/toxfam/model/inference.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import h5py
 import pandas as pd
@@ -21,6 +21,7 @@ from toxfam.device import get_device
 from toxfam.model.model_config import ModelConfig
 
 if TYPE_CHECKING:
+    from toxfam.evaluation.metrics import PlattCalibrator
     from toxfam.model.calibration import ModelWithTemperature
 
 console = Console()
@@ -93,13 +94,26 @@ def load_calibrated_model(
     return scaled_model, model_config, idx_to_label
 
 
-def _load_binary_calibrator(model_dir: str | Path):
-    """Load the deployed binary P(toxic) calibrator, or None if absent.
+class _BinaryCalibration(NamedTuple):
+    """The deployed binary P(toxic) calibrator and its decision threshold.
 
-    ``models/binary_calibrator.json`` is written by ``run_binary_evaluation``
-    when a checkpoint is calibrated. Its absence (older checkpoints) means the
-    raw P(toxic) is used, so this returns None and the caller leaves the score
-    unchanged. See ``toxfam.evaluation.metrics.PlattCalibrator``.
+    Loaded as one unit so the emitted score and the threshold can never be
+    sourced from different score spaces: with a calibrator present both are
+    calibrated; absent, the caller uses the raw score and a raw-space threshold.
+    """
+
+    calibrator: PlattCalibrator
+    threshold: float
+
+
+def _load_binary_calibration(model_dir: str | Path) -> _BinaryCalibration | None:
+    """Load the deployed binary P(toxic) calibrator + threshold, or None if absent.
+
+    ``models/binary_calibrator.json`` is written by ``run_binary_evaluation`` when
+    a checkpoint is calibrated. Its absence (older checkpoints) means the raw
+    P(toxic) is used, so this returns None and both the score and the threshold
+    stay in raw space. Single reader for both fields — see
+    ``prediction._read_optimized_threshold`` and ``run_topk_inference``.
     """
     from toxfam.evaluation.metrics import PlattCalibrator
 
@@ -107,7 +121,8 @@ def _load_binary_calibrator(model_dir: str | Path):
     if not path.exists():
         return None
     try:
-        return PlattCalibrator.from_dict(json.loads(path.read_text()))
+        d = json.loads(path.read_text())
+        return _BinaryCalibration(PlattCalibrator.from_dict(d), float(d["threshold"]))
     except (json.JSONDecodeError, KeyError, ValueError, OSError):
         return None
 
@@ -319,10 +334,10 @@ def run_topk_inference(
     # P(toxic) with the checkpoint's Platt calibrator when present. Monotonic, so
     # it changes no ranking — only the probability value (and the 0.5 point).
     # The family predictions/confidence above are NOT touched.
-    binary_calibrator = _load_binary_calibrator(model_dir)
-    if binary_calibrator is not None:
+    binary_cal = _load_binary_calibration(model_dir)
+    if binary_cal is not None:
         p_toxic = torch.as_tensor(
-            binary_calibrator.transform(p_toxic.numpy()), dtype=torch.float32
+            binary_cal.calibrator.transform(p_toxic.numpy()), dtype=torch.float32
         )
 
     if binary_only:

--- a/src/toxfam/prediction.py
+++ b/src/toxfam/prediction.py
@@ -144,8 +144,14 @@ def _read_optimized_threshold(model_dir: Path) -> float:
     if not path.exists():
         return 0.5
     try:
-        return float(json.loads(path.read_text())["optimized_threshold"])
-    except (KeyError, ValueError, json.JSONDecodeError):
+        data = json.loads(path.read_text())
+        # A calibrated-space threshold whose calibrator is missing/unreadable would
+        # be applied to the RAW P(toxic) that run_topk_inference emits in that case
+        # — a score-space mismatch. Degrade to the raw-space default instead.
+        if data.get("score_space") == "platt_calibrated":
+            return 0.5
+        return float(data["optimized_threshold"])
+    except (KeyError, ValueError, TypeError, json.JSONDecodeError):
         return 0.5
 
 

--- a/src/toxfam/prediction.py
+++ b/src/toxfam/prediction.py
@@ -132,15 +132,14 @@ def _read_optimized_threshold(model_dir: Path) -> float:
     ``run_topk_inference`` now emits. Older checkpoints fall back to the raw
     Youden threshold in ``metrics/binary_metrics.json``.
     """
-    cal_path = model_dir / "models" / "binary_calibrator.json"
-    if cal_path.exists():
-        try:
-            threshold = json.loads(cal_path.read_text()).get("threshold")
-            if threshold is not None:
-                return float(threshold)
-        except (ValueError, json.JSONDecodeError):
-            pass
+    from toxfam.model.inference import _load_binary_calibration
 
+    binary_cal = _load_binary_calibration(model_dir)
+    if binary_cal is not None:
+        return binary_cal.threshold
+
+    # Back-compat: older checkpoints (no calibrator) store a raw-space Youden
+    # threshold here, consistent with the raw P(toxic) emitted in that case.
     path = model_dir / "metrics" / "binary_metrics.json"
     if not path.exists():
         return 0.5

--- a/src/toxfam/prediction.py
+++ b/src/toxfam/prediction.py
@@ -124,7 +124,23 @@ def _organism_mask(df: pd.DataFrame) -> pd.Series:
 
 
 def _read_optimized_threshold(model_dir: Path) -> float:
-    """Read the calibrated binary threshold; fall back to 0.5 if unavailable."""
+    """Read the deployed binary threshold; fall back to 0.5 if unavailable.
+
+    When the checkpoint ships a deployed Platt calibrator
+    (``models/binary_calibrator.json``), its ``threshold`` lives in calibrated
+    score space and must be used against the calibrated P(toxic) that
+    ``run_topk_inference`` now emits. Older checkpoints fall back to the raw
+    Youden threshold in ``metrics/binary_metrics.json``.
+    """
+    cal_path = model_dir / "models" / "binary_calibrator.json"
+    if cal_path.exists():
+        try:
+            threshold = json.loads(cal_path.read_text()).get("threshold")
+            if threshold is not None:
+                return float(threshold)
+        except (ValueError, json.JSONDecodeError):
+            pass
+
     path = model_dir / "metrics" / "binary_metrics.json"
     if not path.exists():
         return 0.5

--- a/src/toxfam/training/strategies.py
+++ b/src/toxfam/training/strategies.py
@@ -198,9 +198,21 @@ def evaluate_label_on_dataset(
         output_dict=True,
         zero_division=0,
     )
+    # Richer calibration metrics than top-1 ECE alone: classwise-ECE/SCE
+    # (per-class reliability a single temperature cannot fix), adaptive ECE,
+    # Brier, NLL. Computed on this split's scores, so the uncalibrated tag and
+    # its `_calibrated` counterpart give an automatic before/after.
+    from toxfam.evaluation.metrics import multiclass_calibration_report
+
+    calibration_metrics = multiclass_calibration_report(y_scores, y_true)
     (out_path / "metrics" / f"{tag}_metrics.json").write_text(
         json.dumps(
-            {"numeric_metrics": metrics, "classification_report": report}, indent=4
+            {
+                "numeric_metrics": metrics,
+                "calibration_metrics": calibration_metrics,
+                "classification_report": report,
+            },
+            indent=4,
         )
     )
 

--- a/tests/test_calibration_metrics.py
+++ b/tests/test_calibration_metrics.py
@@ -1,0 +1,332 @@
+"""Tests for calibration-quality metrics and the binary Platt calibrator.
+
+These cover recommendation #2 (richer calibration metrics beyond top-1 ECE:
+classwise-ECE/SCE, adaptive ECE, Brier, NLL) and recommendation #1 (a separate
+Platt calibrator for the derived binary P(toxic) score).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from sklearn.metrics import log_loss, roc_auc_score
+
+from sklearn.metrics import brier_score_loss
+
+from toxfam.evaluation.metrics import (
+    PlattCalibrator,
+    adaptive_ece,
+    binary_calibration_analysis,
+    binary_calibration_report,
+    brier_score,
+    classwise_ece,
+    classwise_ece_per_class,
+    classwise_ece_weighted,
+    multiclass_calibration_report,
+    nll_score,
+    top_label_ece,
+)
+
+
+# ---------------------------------------------------------------------------
+# top-1 confidence ECE
+# ---------------------------------------------------------------------------
+
+
+def test_top_label_ece_perfectly_calibrated_is_zero():
+    # 100 samples, all predicted class 1 with confidence 0.9; exactly 90 correct.
+    probs = np.tile([0.1, 0.9], (100, 1))
+    labels = np.array([1] * 90 + [0] * 10)
+    assert top_label_ece(probs, labels, n_bins=15) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_top_label_ece_fully_miscalibrated():
+    # Confidence 0.9 on every sample but every prediction is wrong -> ECE = 0.9.
+    probs = np.tile([0.1, 0.9], (100, 1))
+    labels = np.zeros(100, dtype=int)  # true class 0, always predicts class 1
+    assert top_label_ece(probs, labels, n_bins=15) == pytest.approx(0.9, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Brier score
+# ---------------------------------------------------------------------------
+
+
+def test_brier_score_matches_hand_computation():
+    probs = np.array([[0.8, 0.2], [0.3, 0.7]])
+    labels = np.array([0, 1])
+    # sample 0: (0.8-1)^2 + (0.2-0)^2 = 0.08 ; sample 1: (0.3-0)^2 + (0.7-1)^2 = 0.18
+    assert brier_score(probs, labels) == pytest.approx((0.08 + 0.18) / 2)
+
+
+def test_brier_score_zero_when_perfect():
+    probs = np.array([[1.0, 0.0], [0.0, 1.0]])
+    labels = np.array([0, 1])
+    assert brier_score(probs, labels) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# NLL / log loss
+# ---------------------------------------------------------------------------
+
+
+def test_nll_matches_sklearn_log_loss():
+    rng = np.random.default_rng(0)
+    logits = rng.normal(size=(50, 4))
+    probs = np.exp(logits)
+    probs /= probs.sum(axis=1, keepdims=True)
+    labels = rng.integers(0, 4, size=50)
+    assert nll_score(probs, labels) == pytest.approx(
+        log_loss(labels, probs, labels=[0, 1, 2, 3])
+    )
+
+
+# ---------------------------------------------------------------------------
+# classwise-ECE (SCE) and adaptive ECE
+# ---------------------------------------------------------------------------
+
+
+def test_classwise_ece_zero_when_perfectly_calibrated():
+    # Every sample prob [0.6, 0.4]; class frequencies match exactly.
+    probs = np.tile([0.6, 0.4], (100, 1))
+    labels = np.array([0] * 60 + [1] * 40)
+    assert classwise_ece(probs, labels, n_bins=10) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_classwise_ece_detects_per_class_miscalibration():
+    # Predicted prob for class 0 is 0.6 everywhere, but class 0 never occurs.
+    probs = np.tile([0.6, 0.4], (100, 1))
+    labels = np.ones(100, dtype=int)  # all class 1
+    # class 0 contributes |0.6 - 0| = 0.6 ; class 1 contributes |0.4 - 1| = 0.6
+    # SCE = mean of the two per-class ECEs = 0.6
+    assert classwise_ece(probs, labels, n_bins=10) == pytest.approx(0.6, abs=1e-9)
+
+
+def test_classwise_ece_is_nonnegative():
+    rng = np.random.default_rng(1)
+    logits = rng.normal(size=(200, 5))
+    probs = np.exp(logits)
+    probs /= probs.sum(axis=1, keepdims=True)
+    labels = rng.integers(0, 5, size=200)
+    assert classwise_ece(probs, labels) >= 0.0
+
+
+def test_adaptive_ece_confident_but_wrong():
+    # Equal-mass bins are degenerate on tied confidences, but "confident and
+    # always wrong" gives acc=0 in every bin regardless of the split -> 0.9.
+    probs = np.tile([0.1, 0.9], (100, 1))
+    labels = np.zeros(100, dtype=int)
+    assert adaptive_ece(probs, labels, n_bins=10) == pytest.approx(0.9, abs=1e-9)
+
+
+def test_adaptive_ece_bounded():
+    rng = np.random.default_rng(4)
+    logits = rng.normal(size=(200, 3))
+    probs = np.exp(logits)
+    probs /= probs.sum(axis=1, keepdims=True)
+    labels = rng.integers(0, 3, size=200)
+    assert 0.0 <= adaptive_ece(probs, labels) <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# report dict builders
+# ---------------------------------------------------------------------------
+
+
+def test_multiclass_calibration_report_has_expected_keys():
+    rng = np.random.default_rng(2)
+    logits = rng.normal(size=(80, 3))
+    probs = np.exp(logits)
+    probs /= probs.sum(axis=1, keepdims=True)
+    labels = rng.integers(0, 3, size=80)
+    report = multiclass_calibration_report(probs, labels)
+    assert set(report) >= {"ece", "adaptive_ece", "classwise_ece", "brier", "nll"}
+    assert all(isinstance(v, float) for v in report.values())
+
+
+def test_binary_calibration_report_has_expected_keys():
+    rng = np.random.default_rng(3)
+    p = rng.uniform(size=200)
+    y = (rng.uniform(size=200) < p).astype(int)
+    report = binary_calibration_report(p, y)
+    assert set(report) >= {"ece", "brier", "nll"}
+
+
+# ---------------------------------------------------------------------------
+# Platt calibrator (recommendation #1)
+# ---------------------------------------------------------------------------
+
+
+def _overconfident_binary(rng, n):
+    """Scores whose true accuracy is ~p but pushed toward 0/1 (overconfident)."""
+    true_p = rng.uniform(0.05, 0.95, size=n)
+    y = (rng.uniform(size=n) < true_p).astype(int)
+    # sharpen: push probabilities away from 0.5 -> overconfident scores
+    logit = np.log(true_p / (1 - true_p))
+    sharp = 1 / (1 + np.exp(-1.8 * logit))
+    return sharp, y
+
+
+def test_platt_preserves_ranking_and_auc():
+    rng = np.random.default_rng(10)
+    scores, y = _overconfident_binary(rng, 500)
+    cal = PlattCalibrator().fit(scores, y)
+    out = cal.transform(scores)
+    # Platt is a monotonic map -> ROC-AUC (rank-based) is unchanged.
+    assert roc_auc_score(y, out) == pytest.approx(roc_auc_score(y, scores), abs=1e-9)
+    # And it is order-preserving element-wise.
+    order_in = np.argsort(scores)
+    assert np.all(np.diff(out[order_in]) >= -1e-9)
+
+
+def test_platt_reduces_ece_on_overconfident_data():
+    rng = np.random.default_rng(11)
+    fit_scores, fit_y = _overconfident_binary(rng, 2000)
+    test_scores, test_y = _overconfident_binary(rng, 2000)
+    cal = PlattCalibrator().fit(fit_scores, fit_y)
+    raw_ece = binary_calibration_report(test_scores, test_y)["ece"]
+    cal_ece = binary_calibration_report(cal.transform(test_scores), test_y)["ece"]
+    assert cal_ece < raw_ece
+
+
+def test_platt_serialization_roundtrip():
+    rng = np.random.default_rng(12)
+    scores, y = _overconfident_binary(rng, 400)
+    cal = PlattCalibrator().fit(scores, y)
+    restored = PlattCalibrator.from_dict(cal.to_dict())
+    np.testing.assert_allclose(restored.transform(scores), cal.transform(scores))
+
+
+def test_platt_transform_clips_to_unit_interval():
+    rng = np.random.default_rng(13)
+    scores, y = _overconfident_binary(rng, 300)
+    cal = PlattCalibrator().fit(scores, y)
+    out = cal.transform(np.array([0.0, 1.0, 0.5]))
+    assert np.all(out >= 0.0) and np.all(out <= 1.0)
+
+
+# ---------------------------------------------------------------------------
+# binary_calibration_analysis (fit on val, measure on test) — the core of #1
+# ---------------------------------------------------------------------------
+
+
+def test_binary_calibration_analysis_has_expected_structure():
+    rng = np.random.default_rng(20)
+    val_p, val_y = _overconfident_binary(rng, 500)
+    test_p, test_y = _overconfident_binary(rng, 500)
+    out = binary_calibration_analysis(val_p, val_y, test_p, test_y)
+    assert set(out) >= {
+        "platt", "test_raw", "test_calibrated", "delta",
+        "roc_auc_raw", "roc_auc_calibrated",
+    }
+    assert set(out["platt"]) >= {"a", "b"}
+    assert set(out["test_raw"]) >= {"ece", "brier", "nll"}
+
+
+def test_binary_calibration_analysis_preserves_auc():
+    rng = np.random.default_rng(21)
+    val_p, val_y = _overconfident_binary(rng, 800)
+    test_p, test_y = _overconfident_binary(rng, 800)
+    out = binary_calibration_analysis(val_p, val_y, test_p, test_y)
+    # Platt is monotonic -> discrimination (AUC) is unchanged by calibration.
+    assert out["roc_auc_calibrated"] == pytest.approx(out["roc_auc_raw"], abs=1e-9)
+
+
+def test_binary_calibration_analysis_improves_ece_on_overconfident():
+    rng = np.random.default_rng(22)
+    val_p, val_y = _overconfident_binary(rng, 2000)
+    test_p, test_y = _overconfident_binary(rng, 2000)
+    out = binary_calibration_analysis(val_p, val_y, test_p, test_y)
+    # Calibrated ECE is lower than raw -> negative delta.
+    assert out["delta"]["ece"] < 0
+    assert out["test_calibrated"]["ece"] < out["test_raw"]["ece"]
+
+
+def test_binary_calibration_analysis_bootstrap_ci_brackets_point_delta():
+    rng = np.random.default_rng(23)
+    val_p, val_y = _overconfident_binary(rng, 1500)
+    test_p, test_y = _overconfident_binary(rng, 1500)
+    out = binary_calibration_analysis(
+        val_p, val_y, test_p, test_y, n_boot=300, seed=0
+    )
+    assert set(out["delta_ci95"]) >= {"ece", "brier", "nll"}
+    for k in ("ece", "brier", "nll"):
+        lo, hi = out["delta_ci95"][k]
+        assert lo <= hi
+
+
+def test_binary_calibration_analysis_no_ci_by_default():
+    rng = np.random.default_rng(24)
+    val_p, val_y = _overconfident_binary(rng, 400)
+    test_p, test_y = _overconfident_binary(rng, 400)
+    assert "delta_ci95" not in binary_calibration_analysis(val_p, val_y, test_p, test_y)
+
+
+# ---------------------------------------------------------------------------
+# Fixes surfaced by adversarial review
+# ---------------------------------------------------------------------------
+
+
+def test_binary_report_brier_is_standard_binary_brier():
+    # Must equal sklearn's single-event binary Brier, not 2x it.
+    rng = np.random.default_rng(25)
+    p = rng.uniform(size=300)
+    y = (rng.uniform(size=300) < p).astype(int)
+    assert binary_calibration_report(p, y)["brier"] == pytest.approx(
+        brier_score_loss(y, p)
+    )
+
+
+def test_platt_fit_single_class_falls_back_to_identity():
+    cal = PlattCalibrator().fit(np.array([0.2, 0.4, 0.7, 0.9]), np.array([1, 1, 1, 1]))
+    assert cal.a == 1.0 and cal.b == 0.0
+    x = np.array([0.2, 0.5, 0.8])
+    np.testing.assert_allclose(cal.transform(x), x, atol=1e-6)
+
+
+def test_platt_fit_single_sample_is_identity():
+    cal = PlattCalibrator().fit(np.array([0.7]), np.array([1]))
+    assert cal.a == 1.0 and cal.b == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Support-weighted / per-class classwise-ECE (de-dilute the many-class average)
+# ---------------------------------------------------------------------------
+
+
+def _many_class_one_populated_miscalibrated():
+    # 10 classes, 200 samples: class 0 populated (190) and miscalibrated for
+    # its own column (p=0.5 vs true freq 0.95); classes 1..9 are near-empty.
+    n, k = 200, 10
+    probs = np.full((n, k), 0.5 / (k - 1))
+    probs[:, 0] = 0.5
+    labels = np.zeros(n, dtype=int)
+    labels[190:] = np.arange(1, 11)[:10]  # 10 rare samples spread over classes 1..9+
+    labels[190:] = (np.arange(10) % 9) + 1
+    return probs, labels
+
+
+def test_classwise_ece_weighted_zero_when_calibrated():
+    probs = np.tile([0.6, 0.4], (100, 1))
+    labels = np.array([0] * 60 + [1] * 40)
+    assert classwise_ece_weighted(probs, labels, n_bins=10) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_classwise_ece_weighted_exceeds_unweighted_under_dilution():
+    probs, labels = _many_class_one_populated_miscalibrated()
+    unweighted = classwise_ece(probs, labels, n_bins=10)
+    weighted = classwise_ece_weighted(probs, labels, n_bins=10)
+    # Support weighting recovers the populated-class miscalibration the plain
+    # mean dilutes across ~9 near-empty classes.
+    assert weighted > 2 * unweighted
+    assert 0.0 <= weighted <= 1.0
+
+
+def test_classwise_ece_per_class_supports_sum_to_n():
+    probs, labels = _many_class_one_populated_miscalibrated()
+    out = classwise_ece_per_class(probs, labels, n_bins=10)
+    assert len(out) == probs.shape[1]
+    assert sum(e["support"] for e in out) == len(labels)
+    assert all(0.0 <= e["ece"] <= 1.0 for e in out)
+    # The populated class 0 carries the largest per-class ECE here.
+    assert max(out, key=lambda e: e["ece"])["class_index"] == 0

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -174,3 +174,71 @@ def test_run_topk_inference_binary_only(tmp_path, sample_h5):
 
     assert list(out.columns) == ["identifier", "p_toxic"]
     assert len(out) == 2
+
+
+# --------------------------------------------------------------------------- #
+# Deployed binary P(toxic) calibrator (recommendation #1)                      #
+# --------------------------------------------------------------------------- #
+
+
+def _write_binary_calibrator(model_dir, *, a, b, threshold=0.5, eps=1e-6):
+    (model_dir / "models" / "binary_calibrator.json").write_text(
+        json.dumps(
+            {"a": a, "b": b, "eps": eps, "threshold": threshold,
+             "threshold_space": "platt"}
+        )
+    )
+
+
+def test_load_binary_calibrator_roundtrip_and_missing(tmp_path):
+    from toxfam.evaluation.metrics import PlattCalibrator
+    from toxfam.model.inference import _load_binary_calibrator
+
+    model_dir = _make_model_dir(tmp_path)
+    assert _load_binary_calibrator(model_dir) is None  # nothing written yet
+
+    _write_binary_calibrator(model_dir, a=0.7, b=-2.3, threshold=0.2)
+    cal = _load_binary_calibrator(model_dir)
+    x = np.array([0.1, 0.5, 0.9])
+    np.testing.assert_allclose(cal.transform(x), PlattCalibrator(a=0.7, b=-2.3).transform(x))
+
+
+def test_run_topk_inference_applies_binary_calibrator(tmp_path, sample_h5):
+    from toxfam.evaluation.metrics import PlattCalibrator
+
+    model_dir = _make_model_dir(tmp_path)
+    df = pd.DataFrame({"identifier": ["P001", "P002", "P003"]})
+
+    raw = run_topk_inference(df, sample_h5, model_dir, top_k=1)["p_toxic"].to_numpy()
+    _write_binary_calibrator(model_dir, a=0.7, b=-2.3)
+    cal = run_topk_inference(df, sample_h5, model_dir, top_k=1)["p_toxic"].to_numpy()
+
+    np.testing.assert_allclose(
+        cal, PlattCalibrator(a=0.7, b=-2.3).transform(raw), atol=1e-6
+    )
+    assert not np.allclose(cal, raw)  # the calibrator actually moved the score
+
+
+def test_run_topk_inference_identity_calibrator_reproduces_raw(tmp_path, sample_h5):
+    model_dir = _make_model_dir(tmp_path)
+    df = pd.DataFrame({"identifier": ["P001", "P002"]})
+
+    raw = run_topk_inference(df, sample_h5, model_dir)["p_toxic"].to_numpy()
+    _write_binary_calibrator(model_dir, a=1.0, b=0.0)
+    ident = run_topk_inference(df, sample_h5, model_dir)["p_toxic"].to_numpy()
+    np.testing.assert_allclose(ident, raw, atol=1e-6)
+
+
+def test_binary_calibrator_does_not_affect_family_confidence(tmp_path, sample_h5):
+    """Guardrail: the family curation path (run_inference) is untouched by #1."""
+    from toxfam.model.inference import run_inference
+
+    model_dir = _make_model_dir(tmp_path)
+    df = pd.DataFrame({"identifier": ["P001", "P002", "P003"]})
+
+    before = run_inference(df, sample_h5, model_dir)
+    _write_binary_calibrator(model_dir, a=0.7, b=-2.3)
+    after = run_inference(df, sample_h5, model_dir)
+
+    assert list(before["predicted_label"]) == list(after["predicted_label"])
+    np.testing.assert_allclose(before["confidence"], after["confidence"])

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -190,17 +190,20 @@ def _write_binary_calibrator(model_dir, *, a, b, threshold=0.5, eps=1e-6):
     )
 
 
-def test_load_binary_calibrator_roundtrip_and_missing(tmp_path):
+def test_load_binary_calibration_roundtrip_and_missing(tmp_path):
     from toxfam.evaluation.metrics import PlattCalibrator
-    from toxfam.model.inference import _load_binary_calibrator
+    from toxfam.model.inference import _load_binary_calibration
 
     model_dir = _make_model_dir(tmp_path)
-    assert _load_binary_calibrator(model_dir) is None  # nothing written yet
+    assert _load_binary_calibration(model_dir) is None  # nothing written yet
 
     _write_binary_calibrator(model_dir, a=0.7, b=-2.3, threshold=0.2)
-    cal = _load_binary_calibrator(model_dir)
+    bc = _load_binary_calibration(model_dir)
     x = np.array([0.1, 0.5, 0.9])
-    np.testing.assert_allclose(cal.transform(x), PlattCalibrator(a=0.7, b=-2.3).transform(x))
+    np.testing.assert_allclose(
+        bc.calibrator.transform(x), PlattCalibrator(a=0.7, b=-2.3).transform(x)
+    )
+    assert bc.threshold == 0.2  # threshold loaded as a matched unit with the calibrator
 
 
 def test_run_topk_inference_applies_binary_calibrator(tmp_path, sample_h5):

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -206,6 +206,17 @@ def test_load_binary_calibration_roundtrip_and_missing(tmp_path):
     assert bc.threshold == 0.2  # threshold loaded as a matched unit with the calibrator
 
 
+def test_load_binary_calibration_null_threshold_falls_back(tmp_path):
+    """A null/non-numeric threshold must degrade to None (raw path), not crash."""
+    from toxfam.model.inference import _load_binary_calibration
+
+    model_dir = _make_model_dir(tmp_path)
+    (model_dir / "models" / "binary_calibrator.json").write_text(
+        json.dumps({"a": 0.7, "b": -2.3, "eps": 1e-6, "threshold": None})
+    )
+    assert _load_binary_calibration(model_dir) is None
+
+
 def test_run_topk_inference_applies_binary_calibrator(tmp_path, sample_h5):
     from toxfam.evaluation.metrics import PlattCalibrator
 

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -134,6 +134,34 @@ def test_threshold_malformed_json_defaults_to_half(tmp_path):
     assert _read_optimized_threshold(tmp_path) == 0.5
 
 
+def _write_binary_calibrator(model_dir: Path, threshold: float) -> None:
+    models = model_dir / "models"
+    models.mkdir(parents=True, exist_ok=True)
+    (models / "binary_calibrator.json").write_text(
+        json.dumps({"a": 0.7, "b": -2.3, "eps": 1e-6, "threshold": threshold,
+                    "threshold_space": "platt"})
+    )
+
+
+def test_threshold_prefers_deployed_calibrator(tmp_path):
+    """When the deployed calibrator is present, its (calibrated-space) threshold wins."""
+    _write_binary_metrics(tmp_path, json.dumps({"optimized_threshold": 0.73}))
+    _write_binary_calibrator(tmp_path, threshold=0.31)
+    assert _read_optimized_threshold(tmp_path) == pytest.approx(0.31)
+
+
+def test_threshold_falls_back_to_binary_metrics_without_calibrator(tmp_path):
+    _write_binary_metrics(tmp_path, json.dumps({"optimized_threshold": 0.73}))
+    assert _read_optimized_threshold(tmp_path) == pytest.approx(0.73)
+
+
+def test_threshold_malformed_calibrator_falls_back(tmp_path):
+    (tmp_path / "models").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "models" / "binary_calibrator.json").write_text("{bad json")
+    _write_binary_metrics(tmp_path, json.dumps({"optimized_threshold": 0.73}))
+    assert _read_optimized_threshold(tmp_path) == pytest.approx(0.73)
+
+
 # --------------------------------------------------------------------------- #
 # _suffixed                                                                    #
 # --------------------------------------------------------------------------- #

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -162,6 +162,16 @@ def test_threshold_malformed_calibrator_falls_back(tmp_path):
     assert _read_optimized_threshold(tmp_path) == pytest.approx(0.73)
 
 
+def test_threshold_calibrated_metrics_without_calibrator_is_half(tmp_path):
+    """A calibrated-space threshold with no calibrator would be applied to the raw
+    P(toxic) — score-space mismatch; degrade to 0.5 rather than reuse it."""
+    _write_binary_metrics(
+        tmp_path,
+        json.dumps({"optimized_threshold": 0.03, "score_space": "platt_calibrated"}),
+    )
+    assert _read_optimized_threshold(tmp_path) == 0.5
+
+
 # --------------------------------------------------------------------------- #
 # _suffixed                                                                    #
 # --------------------------------------------------------------------------- #

--- a/tests/test_training_smoke.py
+++ b/tests/test_training_smoke.py
@@ -70,11 +70,31 @@ def test_run_training_standard_smoke(tmp_path, monkeypatch, fake_split_manifest)
 
     test_metrics = json.loads((out_dir / "metrics" / "test_metrics.json").read_text())
     assert "numeric_metrics" in test_metrics
+    # Recommendation #2: richer calibration metrics are emitted per split.
+    assert set(test_metrics["calibration_metrics"]) >= {
+        "ece", "adaptive_ece", "classwise_ece", "brier", "nll"
+    }
 
     binary_metrics = json.loads(
         (out_dir / "metrics" / "binary_metrics.json").read_text()
     )
     assert isinstance(binary_metrics, dict) and binary_metrics
+
+    # Recommendation #1: a separate binary Platt-calibration report is written.
+    binary_cal = json.loads(
+        (out_dir / "metrics" / "binary_calibration.json").read_text()
+    )
+    assert set(binary_cal) >= {"platt", "test_raw", "test_calibrated", "delta"}
+    assert set(binary_cal["test_raw"]) >= {"ece", "brier", "nll"}
+
+    # Recommendation #1 DEPLOYED: the calibrator ships with the checkpoint, and the
+    # reported binary metrics/threshold are in calibrated score space.
+    calibrator = json.loads(
+        (out_dir / "models" / "binary_calibrator.json").read_text()
+    )
+    assert set(calibrator) >= {"a", "b", "threshold", "threshold_space"}
+    assert binary_metrics["score_space"] == "platt_calibrated"
+    assert binary_metrics["optimized_threshold"] == pytest.approx(calibrator["threshold"])
 
 
 def _tiny_training_setup(tmp_path, fake_split_manifest):


### PR DESCRIPTION
## Summary

Deploys a dedicated **Platt calibrator** for the derived binary `P(toxic)` score, and adds richer calibration metrics. The family head keeps global temperature scaling (measured well-calibrated: top-1 ECE ~0.006, populated toxin families ≤0.003). The binary `P(toxic) = 1 − P(nontox)` inherits that temperature and reads systematically **over-toxic**; it is now Platt-calibrated on validation and **deployed** — `predict`/`eval` apply `models/binary_calibrator.json` and threshold in calibrated space.

Platt is **monotonic** → **ROC-AUC/PR-AUC and the family predictions/confidence (which drive the confident-error curation) are unchanged.** Measured effect on the binary score: ECE 0.0119→0.0031 (combined), Brier −28%, NLL −38% (all bootstrap 95% CIs exclude zero); default-threshold t=0.5 MCC 0.880→0.900.

## Changes
- `evaluation/metrics.py`: calibration metrics (top-1 / adaptive / classwise / weighted / per-class ECE, Brier, NLL), `PlattCalibrator`, `binary_calibration_analysis` (bootstrap CIs)
- `training/strategies.py`: per-split `calibration_metrics` block
- `evaluation/binary.py`: fit + deploy Platt, refit Youden in calibrated space, persist `models/binary_calibrator.json`; `binary_metrics.json` now reports the calibrated score
- `model/inference.py`: `run_topk_inference` applies the calibrator (`run_inference` untouched — the curation guardrail)
- `prediction.py`: read the calibrated-space threshold from the artifact
- `scripts/package_models.py`: ship the calibrator artifact
- tests: new `test_calibration_metrics.py` + inference/prediction/smoke coverage

## Verification
- 295 unit tests + slow end-to-end smoke green
- Rollout via `toxfam eval binary` on both runs; end-to-end `predict` confirmed to emit `Platt(raw)`
- Guardrail: `run_inference` family predictions/confidence are byte-identical with/without the calibrator (Ivan's confident-error set unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhCjcP1v3vozxg8sLQwNez
