### PR TITLE
feat(calibration): provenance-stamp + deploy-guard the binary calibrator

### DIFF
--- a/paper/figures/numbers_manifest.py
+++ b/paper/figures/numbers_manifest.py
@@ -124,6 +124,23 @@ def _gate_on_pipeline_verification() -> None:
     verify_or_raise("test_set")
 
 
+def _require_deployed_binary_head(bm: dict, bpath, run: str) -> None:
+    """Refuse a pre-deploy (raw) binary_metrics.json.
+
+    Its ROC-AUC/PR-AUC/MCC/F1/threshold are on the RAW P(toxic), not the deployed
+    Platt-calibrated score, and would become silently-wrong manuscript numbers —
+    the same failure mode ``_gate_on_pipeline_verification`` exists to prevent.
+    """
+    if bm.get("score_space") != "platt_calibrated":
+        raise SystemExit(
+            f"{bpath} reports score_space={bm.get('score_space')!r}, not "
+            "'platt_calibrated' — it predates the deployed binary P(toxic) calibrator "
+            "and its numbers are raw (pre-deploy).\n"
+            f"Re-run 'uv run toxfam eval binary model/model_output/{run} --deploy' "
+            "to regenerate it before emitting manuscript numbers."
+        )
+
+
 def main() -> None:
     _gate_on_pipeline_verification()
     classes = test_set_class_list()
@@ -268,6 +285,7 @@ def main() -> None:
         bpath = model_run_dir(run) / "metrics" / "binary_metrics.json"
         if bpath.exists():
             bm = json.loads(bpath.read_text())
+            _require_deployed_binary_head(bm, bpath, run)
             td = bm.get("test_default", {})
             binary[model_name] = {
                 "roc_auc": td.get("roc_auc"), "pr_auc": td.get("pr_auc"),

--- a/paper/tests/test_numbers_manifest.py
+++ b/paper/tests/test_numbers_manifest.py
@@ -1,0 +1,26 @@
+"""The manuscript numbers pipeline must refuse a pre-deploy (raw) binary head."""
+
+from __future__ import annotations
+
+import pytest
+
+from paper.figures.numbers_manifest import _require_deployed_binary_head
+
+
+def test_deployed_binary_head_passes():
+    # score_space=="platt_calibrated" is the deployed head — allowed through.
+    _require_deployed_binary_head(
+        {"score_space": "platt_calibrated"}, "binary_metrics.json", "combined_run"
+    )
+
+
+def test_raw_binary_head_is_refused():
+    with pytest.raises(SystemExit, match="platt_calibrated"):
+        _require_deployed_binary_head(
+            {"score_space": "raw"}, "binary_metrics.json", "combined_run"
+        )
+
+
+def test_missing_score_space_is_refused():
+    with pytest.raises(SystemExit, match="platt_calibrated"):
+        _require_deployed_binary_head({}, "binary_metrics.json", "combined_run")

--- a/scripts/package_models.py
+++ b/scripts/package_models.py
@@ -55,9 +55,14 @@ KEEP_FILES = (
     # `predict test_set/val_set` refuse a checkpoint without it.
     "models/split_provenance.json",
     # Deployed Platt calibrator + Youden threshold for the binary P(toxic) score.
-    # predict/eval apply it (model.inference._load_binary_calibrator); without it
-    # they fall back to the raw score + 0.5. Regenerate via `toxfam eval binary`.
+    # predict/eval apply it (model.inference._load_binary_calibration); without it
+    # they fall back to the raw score + 0.5. Written at training time; to (re)deploy
+    # without retraining use `toxfam eval binary --deploy` (plain `eval binary` is a
+    # diagnostic and does NOT write it).
     "models/binary_calibrator.json",
+    # Binds the calibrator to its split, so `predict test_set/val_set` refuses a
+    # stale one (verify_binary_calibrator_provenance). Required like split_provenance.
+    "models/binary_calibrator.json.provenance.json",
 )
 
 

--- a/src/toxfam/cli.py
+++ b/src/toxfam/cli.py
@@ -681,17 +681,26 @@ def eval_binary(
             exists=True,
         ),
     ],
+    deploy: Annotated[
+        bool,
+        typer.Option(
+            "--deploy/--no-deploy",
+            help="Also re-deploy models/binary_calibrator.json + its provenance "
+            "stamp (default: diagnostic only — do not mutate the shipped calibrator).",
+        ),
+    ] = False,
 ) -> None:
     """Re-compute binary toxic/nontoxin metrics from a trained model.
 
     Loads the calibrated model and config from the model output directory,
     computes P(toxic) for val and test sets, optimizes the threshold on val
     (Youden's J), and evaluates on test with both default and optimized
-    thresholds. Saves binary_metrics.json and ROC/PR plots.
+    thresholds. Saves binary_metrics.json and ROC/PR plots. This is a diagnostic:
+    it does not re-deploy the shipped calibrator unless ``--deploy`` is passed.
     """
     from toxfam.evaluation.runner import run_binary_evaluation_from_dir
 
-    run_binary_evaluation_from_dir(model_dir)
+    run_binary_evaluation_from_dir(model_dir, deploy=deploy)
 
 
 # ---------- toxfam plot ----------

--- a/src/toxfam/data/split_manifest.py
+++ b/src/toxfam/data/split_manifest.py
@@ -337,3 +337,19 @@ def verify_split_provenance(model_dir: str | Path) -> None:
             "commit whose data/splits/split_manifest.csv matches this checkpoint."
         ),
     )
+
+
+def verify_binary_calibrator_provenance(model_dir: str | Path) -> None:
+    """Raise unless the deployed binary P(toxic) calibrator matches the split on disk.
+
+    A no-op when ``models/binary_calibrator.json`` is absent (predict then falls
+    back to the raw score — nothing to pin). When present it must carry a fresh
+    ``.provenance.json`` sidecar, so a calibrator left beside a re-trained
+    checkpoint is caught rather than silently applied to it. Verified only where a
+    split is scored (predict on test_set/val_set), never on arbitrary proteins.
+    """
+    calibrator = Path(model_dir) / "models" / "binary_calibrator.json"
+    if calibrator.exists():
+        verify_provenance(
+            calibrator, label=f"{Path(model_dir).name} (binary calibrator)"
+        )

--- a/src/toxfam/evaluation/binary.py
+++ b/src/toxfam/evaluation/binary.py
@@ -104,6 +104,8 @@ def run_binary_evaluation(
     config: TrainConfig,
     output_dir: Path,
     label_col: str = "Protein families",
+    *,
+    deploy: bool = True,
 ) -> dict:
     """Full binary evaluation: threshold optimization on val, evaluate on test.
 
@@ -169,15 +171,30 @@ def run_binary_evaluation(
 
     # Persist the deployed calibrator next to the checkpoint so it ships with the
     # model and predict/eval load it (see model.inference._load_binary_calibration).
-    models_dir = output_dir / "models"
-    models_dir.mkdir(exist_ok=True)
-    (models_dir / "binary_calibrator.json").write_text(
-        json.dumps(
-            {**calibrator.to_dict(), "threshold": opt_threshold,
-             "threshold_space": "platt"},
-            indent=4,
+    # Deploying is a TRAINING-time act; the diagnostic `toxfam eval binary` passes
+    # deploy=False so re-running it never mutates the shipped calibrator.
+    if deploy:
+        from toxfam.data.split_manifest import write_provenance
+
+        models_dir = output_dir / "models"
+        models_dir.mkdir(exist_ok=True)
+        calibrator_path = models_dir / "binary_calibrator.json"
+        calibrator_path.write_text(
+            json.dumps(
+                {**calibrator.to_dict(), "threshold": opt_threshold,
+                 "threshold_space": "platt"},
+                indent=4,
+            )
         )
-    )
+        # Bind the calibrator to the split it was fit on, so one left beside a
+        # re-trained checkpoint is detected (verify_binary_calibrator_provenance)
+        # rather than silently applied.
+        write_provenance(calibrator_path)
+    else:
+        console.print(
+            "  [dim]Diagnostic mode: not re-deploying "
+            "models/binary_calibrator.json[/]"
+        )
 
     # Save metrics — binary_metrics.json now reports the DEPLOYED (calibrated) score.
     metrics_dir = output_dir / "metrics"

--- a/src/toxfam/evaluation/runner.py
+++ b/src/toxfam/evaluation/runner.py
@@ -477,6 +477,12 @@ def run_model_evaluation(
     # Compute metrics
     task = _get_task(dataset)
     if task == "binary":
+        # This branch fires only for `non_metazoan` (the sole binary-task dataset),
+        # whose ground truth is single-class toxic. It reports the family head's
+        # discrete toxin-vs-nontoxin *label* transfer — deliberately NOT the deployed
+        # calibrated P(toxic)+threshold that predict/eval binary use (score-based, in
+        # binary_metrics.json). A score-based swap here would call roc_auc_score on
+        # single-class labels and raise; the label basis stays graceful (MCC=0).
         metrics = calculate_binary_metrics(
             df["Protein families"], inference_df["predicted_label"]
         )
@@ -517,7 +523,9 @@ def run_model_evaluation(
 # ---------------------------------------------------------------------------
 
 
-def run_binary_evaluation_from_dir(model_dir: str | Path) -> dict:
+def run_binary_evaluation_from_dir(
+    model_dir: str | Path, *, deploy: bool = False
+) -> dict:
     """Re-compute binary toxic/nontoxin metrics from a trained model directory.
 
     Loads the calibrated model and its saved ``config.yaml``, computes P(toxic)
@@ -526,6 +534,11 @@ def run_binary_evaluation_from_dir(model_dir: str | Path) -> dict:
     ``binary_metrics.json`` + ROC/PR plots into ``model_dir``. Returns the
     binary-metrics dict. This is the library entrypoint behind ``toxfam eval
     binary`` (which is a thin delegator to it).
+
+    ``deploy`` defaults to False: this is a re-runnable *diagnostic*, so it does
+    NOT re-write the shipped ``models/binary_calibrator.json`` (deploying is a
+    training-time act). Pass ``deploy=True`` (``toxfam eval binary --deploy``) to
+    deliberately re-deploy the calibrator without retraining.
     """
     from toxfam.config import TrainConfig
     from toxfam.data.dataset import ToxDataset, analyze_data_splits
@@ -561,6 +574,7 @@ def run_binary_evaluation_from_dir(model_dir: str | Path) -> dict:
             )
         results = run_binary_evaluation(
             scaled_model, train_ds.le, val_df, test_df, config, model_dir,
+            deploy=deploy,
         )
     finally:
         train_ds.close()

--- a/src/toxfam/prediction.py
+++ b/src/toxfam/prediction.py
@@ -336,11 +336,16 @@ def run_prediction(
     # test_set / val_set come from the split, so the checkpoint must be pinned to it.
     # Any other input carries no split and needs no manifest.
     if _is_split_dataset(input_tsv):
-        from toxfam.data.split_manifest import verify_split_provenance
+        from toxfam.data.split_manifest import (
+            verify_binary_calibrator_provenance,
+            verify_split_provenance,
+        )
 
         verify_split_provenance(model_dir)
+        verify_binary_calibrator_provenance(model_dir)
         if standard_model_dir is not None:
             verify_split_provenance(standard_model_dir)
+            verify_binary_calibrator_provenance(standard_model_dir)
 
     df, default_h5 = _resolve_input(input_tsv)
     if embeddings_h5 is None and default_h5 is not None:

--- a/tests/test_split_manifest.py
+++ b/tests/test_split_manifest.py
@@ -24,7 +24,9 @@ from toxfam.data.split_manifest import (
     manifest_sha256,
     provenance_path,
     sha256_of,
+    verify_binary_calibrator_provenance,
     verify_split_provenance,
+    write_provenance,
     write_split_provenance,
 )
 
@@ -175,6 +177,51 @@ def test_checkpoint_is_refused_after_the_split_moves(tmp_path, fake_split_manife
 
     with pytest.raises(SplitManifestError, match="different train/val/test split"):
         verify_split_provenance(model_dir)
+
+
+def _write_calibrator(model_dir, *, stamp: bool):
+    """Create models/binary_calibrator.json, optionally with a fresh sidecar."""
+    (model_dir / "models").mkdir(parents=True, exist_ok=True)
+    cal = model_dir / "models" / "binary_calibrator.json"
+    cal.write_text('{"a": 0.7, "b": -2.3, "eps": 1e-6, "threshold": 0.03}')
+    if stamp:
+        write_provenance(cal)
+    return cal
+
+
+def test_binary_calibrator_provenance_is_noop_when_absent(tmp_path, fake_split_manifest):
+    fake_split_manifest(SPLITS)
+    model_dir = tmp_path / "run"
+    (model_dir / "models").mkdir(parents=True)
+    verify_binary_calibrator_provenance(model_dir)  # no calibrator -> must not raise
+
+
+def test_binary_calibrator_pinned_to_current_split_is_accepted(
+    tmp_path, fake_split_manifest
+):
+    fake_split_manifest(SPLITS)
+    model_dir = tmp_path / "run"
+    _write_calibrator(model_dir, stamp=True)
+    verify_binary_calibrator_provenance(model_dir)  # fresh sidecar -> must not raise
+
+
+def test_unstamped_binary_calibrator_is_refused(tmp_path, fake_split_manifest):
+    fake_split_manifest(SPLITS)
+    model_dir = tmp_path / "run"
+    _write_calibrator(model_dir, stamp=False)  # present but no sidecar (pre-feature)
+    with pytest.raises(SplitManifestError, match="not pinned to a split manifest"):
+        verify_binary_calibrator_provenance(model_dir)
+
+
+def test_stale_binary_calibrator_is_refused_after_split_moves(
+    tmp_path, fake_split_manifest
+):
+    fake_split_manifest(SPLITS)
+    model_dir = tmp_path / "run"
+    _write_calibrator(model_dir, stamp=True)
+    fake_split_manifest({"P1": "test", "P2": "train", "P3": "val", "P4": "train"})
+    with pytest.raises(SplitManifestError, match="different train/val/test split"):
+        verify_binary_calibrator_provenance(model_dir)
 
 
 def test_provenance_is_unreadable_when_corrupt(tmp_path, fake_split_manifest):

--- a/tests/test_training_smoke.py
+++ b/tests/test_training_smoke.py
@@ -96,6 +96,18 @@ def test_run_training_standard_smoke(tmp_path, monkeypatch, fake_split_manifest)
     assert binary_metrics["score_space"] == "platt_calibrated"
     assert binary_metrics["optimized_threshold"] == pytest.approx(calibrator["threshold"])
 
+    # Provenance: training (deploy=True) stamps the calibrator to its split.
+    assert (out_dir / "models" / "binary_calibrator.json.provenance.json").exists()
+
+    # The diagnostic re-run (deploy=False by default) must NOT re-deploy the
+    # calibrator — re-running `toxfam eval binary` cannot mutate the shipped artifact.
+    from toxfam.evaluation.runner import run_binary_evaluation_from_dir
+
+    cal_path = out_dir / "models" / "binary_calibrator.json"
+    before = cal_path.read_bytes()
+    run_binary_evaluation_from_dir(out_dir)  # deploy=False default
+    assert cal_path.read_bytes() == before
+
 
 def _tiny_training_setup(tmp_path, fake_split_manifest):
     """Synthetic training data + manifest + embeddings; returns a TrainConfig."""


### PR DESCRIPTION
## Summary

Hardens the just-deployed binary P(toxic) calibrator by closing four design gaps surfaced in the deploy PR's review. **No reported/manuscript number changes** — these are integrity guards, a deploy/diagnostic split, and a doc comment.

1. **Provenance** — `models/binary_calibrator.json` is stamped with the split-manifest hash (`write_provenance` sidecar) at deploy time; `verify_binary_calibrator_provenance` refuses a stale one in the split-scoring `predict` path (`test_set`/`val_set`), never on arbitrary proteins (per the repo's predict-on-arbitrary philosophy). `package_models` ships + requires the sidecar.
2. **Score-space gate** — `numbers_manifest` refuses a `binary_metrics.json` whose `score_space != "platt_calibrated"`, so a pre-deploy (raw) file can't silently feed wrong ROC-AUC/PR-AUC/MCC/threshold into the manuscript.
3. **Deploy vs diagnostic** — `run_binary_evaluation` gains keyword-only `deploy` (default `True` at training); `run_binary_evaluation_from_dir` / `toxfam eval binary` default to `deploy=False` so the diagnostic never mutates the shipped calibrator, with `--deploy` to re-deploy without retraining.
4. **`run_model_evaluation` binary branch** — documented: it fires only on single-class `non_metazoan`; a score-based swap would crash `roc_auc_score` and moves no manuscript number (Table 1 comes from `binary_metrics.json`), so the graceful label basis stays. Full alignment is deferred (needs a two-class binary eval dataset to matter).

## Verification
- 304 unit tests + slow end-to-end smoke green.
- New tests: `verify_binary_calibrator_provenance` (absent/fresh/missing/stale), the score-space gate (3 cases), and the smoke test asserts the sidecar is stamped at training and that the diagnostic re-run leaves the calibrator byte-identical.
- Migration done on the local runs (`toxfam eval binary --deploy`); guards verified against the real checkpoints.
- Adversarial review: correctness-clean; one minor stale-doc-comment finding fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhCjcP1v3vozxg8sLQwNez
